### PR TITLE
feat: convert app into interactive RxJS switchMap visualizer

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,30 +1,156 @@
 :host {
-  font-family: Arial, Helvetica, sans-serif;
-  color: #222;
+  font-family: Inter, Arial, sans-serif;
+  color: #1f2937;
 }
 
-main {
-  max-width: 800px;
-  margin: 40px auto;
-  padding: 0 20px;
+.shell {
+  max-width: 1100px;
+  margin: 28px auto;
+  padding: 0 20px 24px;
 }
 
-h1 {
-  margin-bottom: 12px;
+header h1 {
+  margin-bottom: 6px;
 }
 
-section {
-  margin-top: 18px;
+.card {
+  background: #ffffff;
+  border: 1px solid #d9dee8;
+  border-radius: 12px;
   padding: 16px;
-  border: 1px solid #ddd;
-  border-radius: 8px;
-  background: #fafafa;
+  margin-top: 16px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
 }
 
-code {
-  display: block;
-  margin-top: 6px;
+.menu {
+  max-width: 420px;
+}
+
+.feature-btn {
+  width: 100%;
+  border: none;
+  background: #2563eb;
+  color: #fff;
+  border-radius: 10px;
+  padding: 12px;
+  font-size: 1rem;
+  cursor: pointer;
+}
+
+.controls {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: flex-end;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+button {
+  padding: 9px 12px;
+  border-radius: 8px;
+  border: 1px solid #94a3b8;
+  background: #0f172a;
+  color: #fff;
+  cursor: pointer;
+}
+
+button:disabled {
+  opacity: 0.7;
+  cursor: default;
+}
+
+button.ghost {
   background: #fff;
+  color: #0f172a;
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(280px, 1fr));
+  gap: 12px;
+}
+
+.caption {
+  margin-top: 0;
+  color: #64748b;
+}
+
+.lane {
+  margin-bottom: 12px;
   padding: 10px;
-  border-radius: 6px;
+  border-radius: 10px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+}
+
+.label {
+  display: inline-block;
+  width: 82px;
+  font-weight: 600;
+}
+
+.balls {
+  display: inline-flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.ball {
+  display: inline-flex;
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  align-items: center;
+  justify-content: center;
+  background: #cbd5e1;
+  color: #0f172a;
+  font-size: 0.75rem;
+}
+
+.ball.planned {
+  background: #bfdbfe;
+}
+
+.ball.live {
+  background: #16a34a;
+  color: #fff;
+}
+
+.ball.cut {
+  background: #fecaca;
+  color: #991b1b;
+}
+
+.status {
+  margin-left: 8px;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  color: #166534;
+}
+
+.status.canceled {
+  color: #b91c1c;
+}
+
+.log ul {
+  margin: 0;
+  padding-left: 18px;
+  max-height: 180px;
+  overflow: auto;
+}
+
+@media (max-width: 900px) {
+  .controls {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .board {
+    grid-template-columns: 1fr;
+  }
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,26 +1,83 @@
-<main>
-  <h1>{{ title }}</h1>
-  <p>
-    This Angular 19 app preserves the TypeScript examples that previously logged to the terminal.
-  </p>
+<main class="shell">
+  <header>
+    <h1>RxJS Visual Lab</h1>
+    <p>Choose an operator, then watch how values move through streams.</p>
+  </header>
 
-  <section>
-    <h2>HelloWorld.ts</h2>
-    <code>{{ helloWorld }}</code>
-  </section>
+  @if (selectedFunction === null) {
+    <section class="menu card">
+      <h2>Main menu</h2>
+      <button type="button" class="feature-btn" (click)="openSwitchMapDemo()">
+        1. switchMap demo
+      </button>
+    </section>
+  } @else {
+    <section class="card controls">
+      <div>
+        <h2>Operator: switchMap</h2>
+        <p>
+          Every new source emission starts a fresh inner stream and cancels the previous one.
+        </p>
+      </div>
+      <div class="actions">
+        <button type="button" (click)="runSwitchMapDemo()" [disabled]="running">
+          {{ running ? 'Running…' : 'Run demo' }}
+        </button>
+        <button type="button" (click)="resetDemo()">Reset</button>
+        <button type="button" class="ghost" (click)="backToMenu()">Back to menu</button>
+      </div>
+    </section>
 
-  <section>
-    <h2>Student.ts</h2>
-    <code>{{ studentSummary }}</code>
-  </section>
+    <section class="card board">
+      <div class="column">
+        <h3>Input stream (outer emissions)</h3>
+        <p class="caption">Each row wants to emit 6 inner balls.</p>
+        @for (row of streamRows; track trackById($index, row)) {
+          <div class="lane">
+            <span class="label">Source #{{ row.id }}</span>
+            <div class="balls">
+              @for (slot of ballSlots; track slot) {
+                <span class="ball planned">{{ slot }}</span>
+              }
+            </div>
+          </div>
+        }
+      </div>
 
-  <section>
-    <h2>ApplePhone.ts</h2>
-    <code>{{ applePhoneSummary }}</code>
-  </section>
+      <div class="column">
+        <h3>After switchMap</h3>
+        <p class="caption">Only the newest inner stream keeps flowing.</p>
+        @for (row of streamRows; track trackById($index, row)) {
+          <div class="lane">
+            <span class="label">Output #{{ row.id }}</span>
+            <div class="balls">
+              @for (slot of ballSlots; track slot) {
+                <span
+                  class="ball"
+                  [class.live]="slot <= row.emittedCount"
+                  [class.cut]="row.status === 'canceled' && slot > row.emittedCount"
+                >
+                  {{ slot }}
+                </span>
+              }
+            </div>
+            <span class="status" [class.canceled]="row.status === 'canceled'">
+              {{ row.status }}
+            </span>
+          </div>
+        }
+      </div>
+    </section>
 
-  <section>
-    <h2>typescriptlang-org.ts</h2>
-    <code>7 + 2 = {{ addResult }}</code>
-  </section>
+    <section class="card log">
+      <h3>Emission log</h3>
+      <ul>
+        @for (event of outputEvents; track $index) {
+          <li>
+            t={{ event.atMs }}ms → outer {{ event.outerId }}, inner {{ event.innerIndex }}
+          </li>
+        }
+      </ul>
+    </section>
+  }
 </main>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,47 +1,138 @@
-import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Component, OnDestroy } from '@angular/core';
+import { Subscription, interval, map, switchMap, take, tap } from 'rxjs';
 
-class Student {
-  constructor(public firstName: string, public lastName: string) {}
+type StreamStatus = 'active' | 'completed' | 'canceled';
 
-  getFullName(): string {
-    return `My full name is ${this.firstName} ${this.lastName}`;
-  }
+interface StreamRow {
+  id: number;
+  emittedCount: number;
+  status: StreamStatus;
 }
 
-class MobilePhone {
-  makeCall(): string {
-    return 'Can make a call';
-  }
-
-  sendSms(): string {
-    return 'Can send SMS';
-  }
-}
-
-class ApplePhone extends MobilePhone {
-  useSiri(): string {
-    return 'Can use Siri to control';
-  }
-
-  showFunctions(): string {
-    return `${this.makeCall()}; ${this.sendSms()}; ${this.useSiri()}`;
-  }
+interface OutputEvent {
+  outerId: number;
+  innerIndex: number;
+  atMs: number;
 }
 
 @Component({
   selector: 'app-root',
   standalone: true,
+  imports: [CommonModule],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
 })
-export class AppComponent {
-  protected readonly title = 'TypeScript001 rewritten to Angular 19';
-  protected readonly helloWorld = 'Hello World';
-  protected readonly studentSummary = new Student('Harry', 'Potter').getFullName();
-  protected readonly applePhoneSummary = new ApplePhone().showFunctions();
-  protected readonly addResult = this.add(7, 2);
+export class AppComponent implements OnDestroy {
+  protected selectedFunction: 'switchMap' | null = null;
+  protected running = false;
+  protected streamRows: StreamRow[] = [];
+  protected outputEvents: OutputEvent[] = [];
+  protected readonly ballSlots = [1, 2, 3, 4, 5, 6];
 
-  private add(a: number, b: number): number {
-    return a + b;
+  private demoSub: Subscription | null = null;
+  private activeStreamId: number | null = null;
+  private startedAt = 0;
+
+  protected openSwitchMapDemo(): void {
+    this.selectedFunction = 'switchMap';
+    this.resetDemo();
+  }
+
+  protected backToMenu(): void {
+    this.selectedFunction = null;
+    this.resetDemo();
+  }
+
+  protected runSwitchMapDemo(): void {
+    this.resetDemo();
+    this.running = true;
+    this.startedAt = Date.now();
+
+    const outerStream$ = interval(2200).pipe(
+      take(4),
+      map((value) => value + 1),
+      tap((outerId) => this.activateStream(outerId)),
+      switchMap((outerId) =>
+        interval(450).pipe(
+          take(6),
+          map((innerIndex) => ({
+            outerId,
+            innerIndex: innerIndex + 1,
+            atMs: Date.now() - this.startedAt
+          }))
+        )
+      )
+    );
+
+    this.demoSub = outerStream$.subscribe({
+      next: (event) => this.recordOutput(event),
+      complete: () => {
+        this.running = false;
+        this.markLastActiveAsCompleted();
+      }
+    });
+  }
+
+  protected resetDemo(): void {
+    this.demoSub?.unsubscribe();
+    this.demoSub = null;
+    this.running = false;
+    this.streamRows = [];
+    this.outputEvents = [];
+    this.activeStreamId = null;
+    this.startedAt = 0;
+  }
+
+  protected trackById(_: number, row: StreamRow): number {
+    return row.id;
+  }
+
+  ngOnDestroy(): void {
+    this.demoSub?.unsubscribe();
+  }
+
+  private activateStream(outerId: number): void {
+    if (this.activeStreamId !== null) {
+      const current = this.streamRows.find((row) => row.id === this.activeStreamId);
+      if (current && current.emittedCount < this.ballSlots.length) {
+        current.status = 'canceled';
+      }
+    }
+
+    this.streamRows.push({
+      id: outerId,
+      emittedCount: 0,
+      status: 'active'
+    });
+
+    this.activeStreamId = outerId;
+  }
+
+  private recordOutput(event: OutputEvent): void {
+    this.outputEvents.push(event);
+
+    const row = this.streamRows.find((item) => item.id === event.outerId);
+    if (!row) {
+      return;
+    }
+
+    row.emittedCount = event.innerIndex;
+    if (event.innerIndex === this.ballSlots.length) {
+      row.status = 'completed';
+    }
+  }
+
+  private markLastActiveAsCompleted(): void {
+    if (this.activeStreamId === null) {
+      return;
+    }
+
+    const last = this.streamRows.find((row) => row.id === this.activeStreamId);
+    if (!last) {
+      return;
+    }
+
+    last.status = last.emittedCount === this.ballSlots.length ? 'completed' : 'canceled';
   }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,5 +2,9 @@ html,
 body {
   margin: 0;
   padding: 0;
-  background: #f1f3f5;
+  background: #eef2ff;
+}
+
+* {
+  box-sizing: border-box;
 }


### PR DESCRIPTION
### Motivation
- Provide an interactive web application that demonstrates how RxJS operators work, starting with a visual, easy-to-understand demo for `switchMap`.

### Description
- Rewrote `AppComponent` into an interactive demo component that uses RxJS (`interval`, `take`, `map`, `tap`, `switchMap`) to drive a timed demonstration and track outer/inner emissions and cancellations (`src/app/app.component.ts`).
- Replaced the static example HTML with a main menu and a `switchMap` operator screen that shows input lanes, output lanes (balls), per-row status and an emission log (`src/app/app.component.html`).
- Revamped styling and global CSS to support the demo layout, responsive grid, and visual ball states (`src/app/app.component.css`, `src/styles.css`).
- Added safe teardown and reset logic, TypeScript types/interfaces for stream rows and events, and run/reset/back controls for the demo (`src/app/app.component.ts`).

### Testing
- Ran the automated build with `npm run build`, which completed successfully and produced the application bundle in `dist/`.
- No additional automated unit tests were added; the build is the primary automated validation performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0bab711f88324941600198340b955)