### PR TITLE
Add mergeMap demo and componentize per-demo views; update README and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,77 @@
 # RxJS Visual Lab
 
-This repo is a small Angular 19 app that visualizes RxJS behavior. It currently includes demos for `switchMap` and `exhaustMap`, showing how each operator handles bursts of outer emissions differently.
+RxJS Visual Lab is a standalone Angular app for learning how higher-order RxJS mapping operators handle competing outer emissions and inner streams. The app currently focuses on three interactive visualizations:
+
+- **`switchMap` typeahead** — simulates a user typing `COMPLETED`, starts a request for each typed value, and cancels older in-flight requests when the next value arrives.
+- **`mergeMap` concurrent typeahead** — simulates a user typing `COMPLETED`, starts a request for each typed value, and lets every request complete concurrently.
+- **`exhaustMap` rapid submit** — simulates repeated save-button clicks, accepts the first click while idle, and ignores later clicks until the current request finishes.
+
+The UI shows each demo as a timeline: outer stream events, inner request progress, canceled or ignored work, and the final subscriber output.
+
+## Tech stack
+
+- Angular standalone components
+- Angular control-flow syntax (`@if` / `@for`)
+- RxJS timers, higher-order mapping operators, and side-effect hooks
+- TypeScript strict mode
+- ESLint with Angular ESLint and TypeScript ESLint
+- Karma + Jasmine unit tests
+
+## Repository layout
+
+```text
+.
+├── angular.json                 # Angular CLI build, serve, test, and lint targets
+├── package.json                 # npm scripts and dependencies
+├── src/
+│   ├── main.ts                  # Bootstraps the standalone AppComponent
+│   ├── styles.css               # Global document styles
+│   └── app/
+│       ├── app.component.*      # App shell, demo navigation, UI state, and styles
+│       ├── demo-views/          # Per-demo Angular views and templates
+│       └── demos/
+│           ├── demo.models.ts   # Shared demo types and request phase labels
+│           ├── switch-map-demo.ts
+│           ├── merge-map-demo.ts
+│           └── exhaust-map-demo.ts
+└── tsconfig*.json               # TypeScript and Angular compiler settings
+```
+
+## How the demos work
+
+### `switchMap` demo
+
+The `switchMap` demo emits a progressively longer search term on a timer. Each term creates an inner request stream with multiple progress phases. When a new term arrives before the previous request completes, `switchMap` unsubscribes from the previous inner stream, and the UI marks that request as canceled. After typing settles, only the final request can complete and reach the subscriber.
+
+Key files:
+
+- `src/app/demos/switch-map-demo.ts` builds the timed typing stream and `switchMap` request pipeline.
+- `src/app/app.component.ts` records typed values, request state, cancellations, and subscriber output.
+- `src/app/demo-views/switch-map-demo-view/` renders the typeahead visualization.
+
+### `mergeMap` demo
+
+The `mergeMap` demo uses the same typeahead input pattern as `switchMap`, but it keeps every inner request subscribed. New values do not cancel old work, so multiple requests can progress together and every completed response reaches the subscriber log.
+
+Key files:
+
+- `src/app/demos/merge-map-demo.ts` builds the timed typing stream and `mergeMap` request pipeline.
+- `src/app/app.component.ts` records typed values, concurrent request state, and subscriber output.
+- `src/app/demo-views/merge-map-demo-view/` renders the concurrent typeahead visualization.
+
+### `exhaustMap` demo
+
+The `exhaustMap` demo emits a scheduled sequence of save clicks. The first click starts an inner request stream. While that request is active, later clicks are recorded as ignored by the visualization and do not create new inner request work. Once the request completes, the next click that arrives while idle can start a new request.
+
+Key files:
+
+- `src/app/demos/exhaust-map-demo.ts` builds the click schedule and `exhaustMap` request pipeline.
+- `src/app/app.component.ts` records accepted and ignored clicks, request state, and subscriber output.
+- `src/app/demo-views/exhaust-map-demo-view/` renders the rapid-submit visualization.
 
 ## Prerequisites
 
-- Node.js
-- npm
-
-Verified locally with:
+Install Node.js and npm. The project has been verified locally with:
 
 - Node.js `v22.21.0`
 - npm `11.6.4`
@@ -34,10 +98,12 @@ http://localhost:4200
 
 Notes:
 
-- The dev server runs in watch mode, so it rebuilds when you change files.
-- If port `4200` is already in use, Angular CLI will ask to use a different port.
+- The dev server runs in watch mode and rebuilds when source files change.
+- If port `4200` is already in use, Angular CLI may prompt you to choose another port.
 
-## Create a production build
+## Build
+
+Create a production build:
 
 ```bash
 npm run build
@@ -49,22 +115,40 @@ The build output is written to:
 dist/typescript001-angular19
 ```
 
-## Lint the code
+## Test and lint
 
-```bash
-npm run lint
-```
-
-## Tests
-
-Run the unit tests once in headless Chrome:
+Run unit tests once in headless Chrome:
 
 ```bash
 npm test
 ```
 
-For watch mode during local development:
+Run tests in watch mode during development:
 
 ```bash
 npm run test:watch
 ```
+
+Lint TypeScript and Angular templates:
+
+```bash
+npm run lint
+```
+
+## Available npm scripts
+
+| Script | Description |
+| --- | --- |
+| `npm start` | Runs `ng serve` for local development. |
+| `npm run build` | Creates a production build. |
+| `npm test` | Runs Karma/Jasmine tests once in Chrome Headless. |
+| `npm run test:watch` | Runs Karma/Jasmine tests in watch mode. |
+| `npm run lint` | Runs Angular ESLint over app TypeScript and templates. |
+
+## Development notes
+
+- The app uses a standalone root component, so there is no Angular module file.
+- Demo logic is kept in `src/app/demos/` to separate RxJS stream behavior from UI rendering.
+- Per-demo templates live in `src/app/demo-views/`, keeping `app.component.html` focused on menu and demo selection.
+- Request progress is simulated with RxJS `timer` and a shared phase list, not real HTTP calls.
+- `resetDemo()` unsubscribes from the current demo subscription so active timers stop when changing demos or resetting the view.

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -60,6 +60,10 @@ header h1 {
   background: linear-gradient(135deg, #c2410c, #7c2d12);
 }
 
+.feature-btn.tertiary {
+  background: linear-gradient(135deg, #2563eb, #1e3a8a);
+}
+
 .controls {
   display: flex;
   justify-content: space-between;

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -8,296 +8,63 @@
     <section class="menu card">
       <h2>Main menu</h2>
       <div class="feature-grid">
-        <button type="button" class="feature-btn" (click)="openSwitchMapDemo()">
-          switchMap
-        </button>
-        <button
-          type="button"
-          class="feature-btn secondary"
-          (click)="openExhaustMapDemo()"
-        >
-          exhaustMap
-        </button>
-      </div>
-    </section>
-  } @else if (selectedFunction === 'switchMap') {
-    <section class="card controls">
-      <div>
-        <h2>Operator: switchMap</h2>
-        <p>
-          Each new typed value starts a fresh inner request and cancels the previous one.
-        </p>
-      </div>
-      <div class="actions">
-        <button type="button" (click)="runSwitchMapDemo()" [disabled]="running">
-          {{ running ? 'Typing...' : 'Run demo' }}
-        </button>
-        <button type="button" (click)="resetDemo()">Reset</button>
-        <button type="button" class="ghost" (click)="backToMenu()">Back to menu</button>
-      </div>
-    </section>
-
-    <section class="card hero">
-      <div>
-        <p class="eyebrow">Typeahead simulation</p>
-        <h3>Search box: {{ typedTerm || '_' }}</h3>
-        <p class="caption">
-          The outer stream emits C, CO, COM, COMP, and keeps going until COMPLETED.
-        </p>
-      </div>
-
-      <div class="letter-strip" aria-label="Typing target word">
-        @for (letter of demoLetters; track $index) {
-          <span class="letter" [class.typed]="$index < typedTerm.length">
-            {{ letter }}
-          </span>
-        }
-      </div>
-    </section>
-
-    <section class="board">
-      <section class="card column">
-        <h3>Outer stream: typing</h3>
-        <p class="caption">Every key press emits the latest input value.</p>
-
-        @if (typingEvents.length === 0) {
-          <p class="empty">Run the demo to emit C, CO, COM, and the rest of the word.</p>
-        } @else {
-          <ul class="event-list">
-            @for (event of typingEvents; track event.id) {
-              <li>
-                <span class="time">t={{ event.atMs }}ms</span>
-                <code>{{ event.term }}</code>
-              </li>
-            }
-          </ul>
-        }
-      </section>
-
-      <section class="card column">
-        <h3>Inner stream: requests</h3>
-        <p class="caption">switchMap keeps only the latest request alive.</p>
-
-        @if (requestRows.length === 0) {
-          <p class="empty">No inner request has been created yet.</p>
-        } @else {
-          <div class="request-list">
-            @for (request of requestRows; track request.id) {
-              <article
-                class="request-card"
-                [class.canceled]="request.status === 'canceled'"
-                [class.completed]="request.status === 'completed'"
-              >
-                <div class="request-head">
-                  <div>
-                    <p class="request-label">Request {{ request.id }}</p>
-                    <strong>{{ request.value }}</strong>
-                  </div>
-                  <span
-                    class="status-chip"
-                    [class.canceled]="request.status === 'canceled'"
-                    [class.completed]="request.status === 'completed'"
-                  >
-                    {{ request.status }}
-                  </span>
-                </div>
-
-                <div class="progress-track" aria-hidden="true">
-                  <span class="progress-fill" [style.width.%]="request.progressPercent"></span>
-                </div>
-
-                <p class="request-note">{{ request.note }}</p>
-              </article>
-            }
-          </div>
-        }
-      </section>
-    </section>
-
-    <section class="card results">
-      <div class="result-panel">
-        <h3>After switchMap</h3>
-        <p class="caption">
-          Canceled requests never reach the subscriber. Only the latest term survives.
-        </p>
-
-        <div class="result-display">
-          @if (latestResponse.length > 0) {
-            <p class="result-message">{{ latestResponse }}</p>
-            <p class="result-note">Only "COMPLETED" makes it through after typing settles.</p>
-          } @else {
-            <p class="empty">No response has reached the subscriber yet.</p>
-          }
-        </div>
-      </div>
-
-      <div class="result-panel">
-        <h3>Subscriber log</h3>
-
-        @if (outputEvents.length === 0) {
-          <p class="empty">The log stays empty until the last request completes.</p>
-        } @else {
-          <ul class="event-list compact">
-            @for (event of outputEvents; track event.requestId) {
-              <li>
-                <span class="time">t={{ event.atMs }}ms</span>
-                {{ event.message }}
-              </li>
-            }
-          </ul>
-        }
-      </div>
-    </section>
-  } @else if (selectedFunction === 'exhaustMap') {
-    <section class="card controls">
-      <div>
-        <h2>Operator: exhaustMap</h2>
-        <p>
-          The first click starts a request, then every later click is ignored until that request
-          finishes.
-        </p>
-      </div>
-      <div class="actions">
-        <button type="button" (click)="runExhaustMapDemo()" [disabled]="running">
-          {{ running ? 'Submitting...' : 'Run demo' }}
-        </button>
-        <button type="button" (click)="resetDemo()">Reset</button>
-        <button type="button" class="ghost" (click)="backToMenu()">Back to menu</button>
-      </div>
-    </section>
-
-    <section class="card hero">
-      <div>
-        <p class="eyebrow">Rapid-submit simulation</p>
-        <h3>Button mash: save draft</h3>
-        <p class="caption">
-          Six clicks arrive in bursts. exhaustMap accepts the first click in each free window and
-          ignores the rest while a request is still active.
-        </p>
-      </div>
-
-      <div class="click-strip" aria-label="Scheduled submit clicks">
-        @for (click of exhaustClickPlan; track click.label; let index = $index) {
-          <span
-            class="click-pill"
-            [class.accepted]="index < submitAttempts.length && submitAttempts[index].status === 'accepted'"
-            [class.ignored]="index < submitAttempts.length && submitAttempts[index].status === 'ignored'"
+        @for (demo of demoMenuItems; track demo.operator) {
+          <button
+            type="button"
+            class="feature-btn"
+            [class.secondary]="demo.variant === 'secondary'"
+            [class.tertiary]="demo.variant === 'tertiary'"
+            (click)="openDemo(demo.operator)"
           >
-            {{ click.label }}
-          </span>
+            {{ demo.label }}
+          </button>
         }
       </div>
     </section>
-
-    <section class="board">
-      <section class="card column">
-        <h3>Outer stream: submit clicks</h3>
-        <p class="caption">Every click still emits. exhaustMap decides which ones can enter.</p>
-
-        @if (submitAttempts.length === 0) {
-          <p class="empty">Run the demo to emit a burst of rapid submit clicks.</p>
-        } @else {
-          <ul class="event-list attempts">
-            @for (attempt of submitAttempts; track attempt.id) {
-              <li>
-                <div class="attempt-row">
-                  <div class="attempt-meta">
-                    <span class="time">t={{ attempt.atMs }}ms</span>
-                    <strong>{{ attempt.label }}</strong>
-                  </div>
-                  <span
-                    class="attempt-status"
-                    [class.accepted]="attempt.status === 'accepted'"
-                    [class.ignored]="attempt.status === 'ignored'"
-                  >
-                    {{ attempt.status }}
-                  </span>
-                </div>
-                <p class="attempt-note">{{ attempt.note }}</p>
-              </li>
-            }
-          </ul>
-        }
-      </section>
-
-      <section class="card column">
-        <h3>Inner stream: requests</h3>
-        <p class="caption">Only accepted clicks create a request. Ignored clicks do nothing.</p>
-
-        @if (requestRows.length === 0) {
-          <p class="empty">No request has started yet.</p>
-        } @else {
-          <div class="request-list">
-            @for (request of requestRows; track request.id) {
-              <article
-                class="request-card"
-                [class.canceled]="request.status === 'canceled'"
-                [class.completed]="request.status === 'completed'"
-              >
-                <div class="request-head">
-                  <div>
-                    <p class="request-label">Request {{ request.id }}</p>
-                    <strong>{{ request.value }}</strong>
-                  </div>
-                  <span
-                    class="status-chip"
-                    [class.canceled]="request.status === 'canceled'"
-                    [class.completed]="request.status === 'completed'"
-                  >
-                    {{ request.status }}
-                  </span>
-                </div>
-
-                <div class="progress-track" aria-hidden="true">
-                  <span class="progress-fill" [style.width.%]="request.progressPercent"></span>
-                </div>
-
-                <p class="request-note">{{ request.note }}</p>
-              </article>
-            }
-          </div>
-        }
-      </section>
-    </section>
-
-    <section class="card results">
-      <div class="result-panel">
-        <h3>After exhaustMap</h3>
-        <p class="caption">
-          Ignored clicks never open inner streams. The subscriber only sees responses from accepted
-          clicks.
-        </p>
-
-        <div class="result-display">
-          @if (latestResponse.length > 0) {
-            <p class="result-message">{{ latestResponse }}</p>
-            @if (ignoredAttemptSummary.length > 0) {
-              <p class="result-note">Ignored clicks: {{ ignoredAttemptSummary }}.</p>
-            } @else {
-              <p class="result-note">Every click was accepted because no request was busy.</p>
-            }
-          } @else {
-            <p class="empty">No save has reached the subscriber yet.</p>
-          }
-        </div>
-      </div>
-
-      <div class="result-panel">
-        <h3>Subscriber log</h3>
-
-        @if (outputEvents.length === 0) {
-          <p class="empty">Only accepted clicks will appear here after their request finishes.</p>
-        } @else {
-          <ul class="event-list compact">
-            @for (event of outputEvents; track event.requestId) {
-              <li>
-                <span class="time">t={{ event.atMs }}ms</span>
-                {{ event.message }}
-              </li>
-            }
-          </ul>
-        }
-      </div>
-    </section>
+  } @else {
+    @switch (selectedFunction) {
+      @case ('switchMap') {
+        <app-switch-map-demo-view
+          [running]="running"
+          [typedTerm]="typedTerm"
+          [demoLetters]="demoLetters"
+          [typingEvents]="typingEvents"
+          [requestRows]="requestRows"
+          [outputEvents]="outputEvents"
+          [latestResponse]="latestResponse"
+          (runDemo)="runSwitchMapDemo()"
+          (resetDemo)="resetDemo()"
+          (backToMenu)="backToMenu()"
+        />
+      }
+      @case ('mergeMap') {
+        <app-merge-map-demo-view
+          [running]="running"
+          [typedTerm]="typedTerm"
+          [demoLetters]="demoLetters"
+          [typingEvents]="typingEvents"
+          [requestRows]="requestRows"
+          [outputEvents]="outputEvents"
+          [latestResponse]="latestResponse"
+          (runDemo)="runMergeMapDemo()"
+          (resetDemo)="resetDemo()"
+          (backToMenu)="backToMenu()"
+        />
+      }
+      @case ('exhaustMap') {
+        <app-exhaust-map-demo-view
+          [running]="running"
+          [submitAttempts]="submitAttempts"
+          [requestRows]="requestRows"
+          [outputEvents]="outputEvents"
+          [latestResponse]="latestResponse"
+          [exhaustClickPlan]="exhaustClickPlan"
+          [ignoredAttemptSummary]="ignoredAttemptSummary"
+          (runDemo)="runExhaustMapDemo()"
+          (resetDemo)="resetDemo()"
+          (backToMenu)="backToMenu()"
+        />
+      }
+    }
   }
 </main>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -25,7 +25,23 @@ describe('AppComponent', () => {
 
     expect(compiled.querySelector('h1')?.textContent).toContain('RxJS Visual Lab');
     expect(featureButtons).toContain('switchMap');
+    expect(featureButtons).toContain('mergeMap');
     expect(featureButtons).toContain('exhaustMap');
+  });
+
+  it('opens the mergeMap demo', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const mergeButton = Array.from(compiled.querySelectorAll('.feature-btn')).find((button) =>
+      button.textContent?.includes('mergeMap')
+    ) as HTMLButtonElement | undefined;
+
+    mergeButton?.click();
+    fixture.detectChanges();
+
+    expect(compiled.querySelector('.controls h2')?.textContent).toContain('Operator: mergeMap');
   });
 
   it('opens the exhaustMap demo', () => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,8 @@
-import { Component, OnDestroy } from '@angular/core';
+import { Component, OnDestroy, ViewEncapsulation } from '@angular/core';
 import { Subscription } from 'rxjs';
+import { ExhaustMapDemoViewComponent } from './demo-views/exhaust-map-demo-view/exhaust-map-demo-view.component';
+import { MergeMapDemoViewComponent } from './demo-views/merge-map-demo-view/merge-map-demo-view.component';
+import { SwitchMapDemoViewComponent } from './demo-views/switch-map-demo-view/switch-map-demo-view.component';
 import {
   EXHAUST_MAP_CLICK_PLAN,
   createExhaustMapDemo
@@ -13,17 +16,32 @@ import {
   SubmitAttempt,
   TypingEvent
 } from './demos/demo.models';
+import { createMergeMapDemo } from './demos/merge-map-demo';
 import {
   SWITCH_MAP_DEMO_LETTERS,
   SWITCH_MAP_DEMO_WORD,
   createSwitchMapDemo
 } from './demos/switch-map-demo';
 
+type DemoVariant = 'primary' | 'secondary' | 'tertiary';
+
+interface DemoMenuItem {
+  operator: DemoOperator;
+  label: string;
+  variant: DemoVariant;
+}
+
 @Component({
   selector: 'app-root',
   standalone: true,
+  imports: [
+    SwitchMapDemoViewComponent,
+    MergeMapDemoViewComponent,
+    ExhaustMapDemoViewComponent
+  ],
   templateUrl: './app.component.html',
-  styleUrl: './app.component.css'
+  styleUrl: './app.component.css',
+  encapsulation: ViewEncapsulation.None
 })
 export class AppComponent implements OnDestroy {
   protected selectedFunction: DemoOperator | null = null;
@@ -38,6 +56,11 @@ export class AppComponent implements OnDestroy {
   protected readonly demoLetters = SWITCH_MAP_DEMO_LETTERS;
   protected readonly requestPhases = REQUEST_PHASES;
   protected readonly exhaustClickPlan = EXHAUST_MAP_CLICK_PLAN;
+  protected readonly demoMenuItems: DemoMenuItem[] = [
+    { operator: 'switchMap', label: 'switchMap', variant: 'primary' },
+    { operator: 'mergeMap', label: 'mergeMap', variant: 'tertiary' },
+    { operator: 'exhaustMap', label: 'exhaustMap', variant: 'secondary' }
+  ];
 
   private readonly typingDelayMs = 280;
   private readonly requestStepDelayMs = 260;
@@ -50,12 +73,9 @@ export class AppComponent implements OnDestroy {
       .join(', ');
   }
 
-  protected openSwitchMapDemo(): void {
-    this.openDemo('switchMap');
-  }
-
-  protected openExhaustMapDemo(): void {
-    this.openDemo('exhaustMap');
+  protected openDemo(operator: DemoOperator): void {
+    this.selectedFunction = operator;
+    this.resetDemo();
   }
 
   protected backToMenu(): void {
@@ -68,6 +88,28 @@ export class AppComponent implements OnDestroy {
     this.running = true;
 
     this.demoSub = createSwitchMapDemo({
+      demoWord: this.demoWord,
+      typingDelayMs: this.typingDelayMs,
+      requestPhases: this.requestPhases,
+      requestStepDelayMs: this.requestStepDelayMs,
+      recordTypedTerm: (term, atMs) => this.recordTypedTerm(term, atMs),
+      startRequest: (value, note) => this.startRequest(value, note),
+      advanceRequest: (requestId, progressStep, note) =>
+        this.advanceRequest(requestId, progressStep, note),
+      completeRequest: (event, note) => this.recordOutput(event, note),
+      cancelRequest: (requestId, note) => this.cancelRequest(requestId, note)
+    }).subscribe({
+      complete: () => {
+        this.running = false;
+      }
+    });
+  }
+
+  protected runMergeMapDemo(): void {
+    this.resetDemo();
+    this.running = true;
+
+    this.demoSub = createMergeMapDemo({
       demoWord: this.demoWord,
       typingDelayMs: this.typingDelayMs,
       requestPhases: this.requestPhases,
@@ -121,11 +163,6 @@ export class AppComponent implements OnDestroy {
 
   ngOnDestroy(): void {
     this.demoSub?.unsubscribe();
-  }
-
-  private openDemo(operator: DemoOperator): void {
-    this.selectedFunction = operator;
-    this.resetDemo();
   }
 
   private recordTypedTerm(term: string, atMs: number): void {

--- a/src/app/demo-views/exhaust-map-demo-view/exhaust-map-demo-view.component.html
+++ b/src/app/demo-views/exhaust-map-demo-view/exhaust-map-demo-view.component.html
@@ -1,0 +1,146 @@
+<section class="card controls">
+  <div>
+    <h2>Operator: exhaustMap</h2>
+    <p>The first click starts a request, then every later click is ignored until that request finishes.</p>
+  </div>
+  <div class="actions">
+    <button type="button" (click)="runDemo.emit()" [disabled]="running">
+      {{ running ? 'Submitting...' : 'Run demo' }}
+    </button>
+    <button type="button" (click)="resetDemo.emit()">Reset</button>
+    <button type="button" class="ghost" (click)="backToMenu.emit()">Back to menu</button>
+  </div>
+</section>
+
+<section class="card hero">
+  <div>
+    <p class="eyebrow">Rapid-submit simulation</p>
+    <h3>Button mash: save draft</h3>
+    <p class="caption">
+      Six clicks arrive in bursts. exhaustMap accepts the first click in each free window and ignores
+      the rest while a request is still active.
+    </p>
+  </div>
+
+  <div class="click-strip" aria-label="Scheduled submit clicks">
+    @for (click of exhaustClickPlan; track click.label; let index = $index) {
+      <span
+        class="click-pill"
+        [class.accepted]="index < submitAttempts.length && submitAttempts[index].status === 'accepted'"
+        [class.ignored]="index < submitAttempts.length && submitAttempts[index].status === 'ignored'"
+      >
+        {{ click.label }}
+      </span>
+    }
+  </div>
+</section>
+
+<section class="board">
+  <section class="card column">
+    <h3>Outer stream: submit clicks</h3>
+    <p class="caption">Every click still emits. exhaustMap decides which ones can enter.</p>
+
+    @if (submitAttempts.length === 0) {
+      <p class="empty">Run the demo to emit a burst of rapid submit clicks.</p>
+    } @else {
+      <ul class="event-list attempts">
+        @for (attempt of submitAttempts; track attempt.id) {
+          <li>
+            <div class="attempt-row">
+              <div class="attempt-meta">
+                <span class="time">t={{ attempt.atMs }}ms</span>
+                <strong>{{ attempt.label }}</strong>
+              </div>
+              <span
+                class="attempt-status"
+                [class.accepted]="attempt.status === 'accepted'"
+                [class.ignored]="attempt.status === 'ignored'"
+              >
+                {{ attempt.status }}
+              </span>
+            </div>
+            <p class="attempt-note">{{ attempt.note }}</p>
+          </li>
+        }
+      </ul>
+    }
+  </section>
+
+  <section class="card column">
+    <h3>Inner stream: requests</h3>
+    <p class="caption">Only accepted clicks create a request. Ignored clicks do nothing.</p>
+
+    @if (requestRows.length === 0) {
+      <p class="empty">No request has started yet.</p>
+    } @else {
+      <div class="request-list">
+        @for (request of requestRows; track request.id) {
+          <article
+            class="request-card"
+            [class.canceled]="request.status === 'canceled'"
+            [class.completed]="request.status === 'completed'"
+          >
+            <div class="request-head">
+              <div>
+                <p class="request-label">Request {{ request.id }}</p>
+                <strong>{{ request.value }}</strong>
+              </div>
+              <span
+                class="status-chip"
+                [class.canceled]="request.status === 'canceled'"
+                [class.completed]="request.status === 'completed'"
+              >
+                {{ request.status }}
+              </span>
+            </div>
+
+            <div class="progress-track" aria-hidden="true">
+              <span class="progress-fill" [style.width.%]="request.progressPercent"></span>
+            </div>
+
+            <p class="request-note">{{ request.note }}</p>
+          </article>
+        }
+      </div>
+    }
+  </section>
+</section>
+
+<section class="card results">
+  <div class="result-panel">
+    <h3>After exhaustMap</h3>
+    <p class="caption">
+      Ignored clicks never open inner streams. The subscriber only sees responses from accepted clicks.
+    </p>
+
+    <div class="result-display">
+      @if (latestResponse.length > 0) {
+        <p class="result-message">{{ latestResponse }}</p>
+        @if (ignoredAttemptSummary.length > 0) {
+          <p class="result-note">Ignored clicks: {{ ignoredAttemptSummary }}.</p>
+        } @else {
+          <p class="result-note">Every click was accepted because no request was busy.</p>
+        }
+      } @else {
+        <p class="empty">No save has reached the subscriber yet.</p>
+      }
+    </div>
+  </div>
+
+  <div class="result-panel">
+    <h3>Subscriber log</h3>
+
+    @if (outputEvents.length === 0) {
+      <p class="empty">Only accepted clicks will appear here after their request finishes.</p>
+    } @else {
+      <ul class="event-list compact">
+        @for (event of outputEvents; track event.requestId) {
+          <li>
+            <span class="time">t={{ event.atMs }}ms</span>
+            {{ event.message }}
+          </li>
+        }
+      </ul>
+    }
+  </div>
+</section>

--- a/src/app/demo-views/exhaust-map-demo-view/exhaust-map-demo-view.component.ts
+++ b/src/app/demo-views/exhaust-map-demo-view/exhaust-map-demo-view.component.ts
@@ -1,0 +1,26 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+  OutputEvent,
+  RequestRow,
+  ScheduledClick,
+  SubmitAttempt
+} from '../../demos/demo.models';
+
+@Component({
+  selector: 'app-exhaust-map-demo-view',
+  standalone: true,
+  templateUrl: './exhaust-map-demo-view.component.html'
+})
+export class ExhaustMapDemoViewComponent {
+  @Input() running = false;
+  @Input() submitAttempts: SubmitAttempt[] = [];
+  @Input() requestRows: RequestRow[] = [];
+  @Input() outputEvents: OutputEvent[] = [];
+  @Input() latestResponse = '';
+  @Input() exhaustClickPlan: ScheduledClick[] = [];
+  @Input() ignoredAttemptSummary = '';
+
+  @Output() runDemo = new EventEmitter<void>();
+  @Output() resetDemo = new EventEmitter<void>();
+  @Output() backToMenu = new EventEmitter<void>();
+}

--- a/src/app/demo-views/merge-map-demo-view/merge-map-demo-view.component.html
+++ b/src/app/demo-views/merge-map-demo-view/merge-map-demo-view.component.html
@@ -1,0 +1,121 @@
+<section class="card controls">
+  <div>
+    <h2>Operator: mergeMap</h2>
+    <p>Each typed value starts an inner request, and every request keeps running concurrently.</p>
+  </div>
+  <div class="actions">
+    <button type="button" (click)="runDemo.emit()" [disabled]="running">
+      {{ running ? 'Typing...' : 'Run demo' }}
+    </button>
+    <button type="button" (click)="resetDemo.emit()">Reset</button>
+    <button type="button" class="ghost" (click)="backToMenu.emit()">Back to menu</button>
+  </div>
+</section>
+
+<section class="card hero">
+  <div>
+    <p class="eyebrow">Concurrent typeahead simulation</p>
+    <h3>Search box: {{ typedTerm || '_' }}</h3>
+    <p class="caption">The outer stream emits C, CO, COM, COMP, and keeps going until COMPLETED while every request remains active.</p>
+  </div>
+
+  <div class="letter-strip" aria-label="Typing target word">
+    @for (letter of demoLetters; track $index) {
+      <span class="letter" [class.typed]="$index < typedTerm.length">
+        {{ letter }}
+      </span>
+    }
+  </div>
+</section>
+
+<section class="board">
+  <section class="card column">
+    <h3>Outer stream: typing</h3>
+    <p class="caption">Every key press emits the latest input value.</p>
+
+    @if (typingEvents.length === 0) {
+      <p class="empty">Run the demo to emit C, CO, COM, and the rest of the word.</p>
+    } @else {
+      <ul class="event-list">
+        @for (event of typingEvents; track event.id) {
+          <li>
+            <span class="time">t={{ event.atMs }}ms</span>
+            <code>{{ event.term }}</code>
+          </li>
+        }
+      </ul>
+    }
+  </section>
+
+  <section class="card column">
+    <h3>Inner stream: requests</h3>
+    <p class="caption">mergeMap lets all inner requests run at the same time.</p>
+
+    @if (requestRows.length === 0) {
+      <p class="empty">No inner request has been created yet.</p>
+    } @else {
+      <div class="request-list">
+        @for (request of requestRows; track request.id) {
+          <article
+            class="request-card"
+            [class.canceled]="request.status === 'canceled'"
+            [class.completed]="request.status === 'completed'"
+          >
+            <div class="request-head">
+              <div>
+                <p class="request-label">Request {{ request.id }}</p>
+                <strong>{{ request.value }}</strong>
+              </div>
+              <span
+                class="status-chip"
+                [class.canceled]="request.status === 'canceled'"
+                [class.completed]="request.status === 'completed'"
+              >
+                {{ request.status }}
+              </span>
+            </div>
+
+            <div class="progress-track" aria-hidden="true">
+              <span class="progress-fill" [style.width.%]="request.progressPercent"></span>
+            </div>
+
+            <p class="request-note">{{ request.note }}</p>
+          </article>
+        }
+      </div>
+    }
+  </section>
+</section>
+
+<section class="card results">
+  <div class="result-panel">
+    <h3>After mergeMap</h3>
+    <p class="caption">No request is canceled or ignored. Every response can reach the subscriber.</p>
+
+    <div class="result-display">
+      @if (latestResponse.length > 0) {
+        <p class="result-message">{{ latestResponse }}</p>
+        <p class="result-note">The latest display updates each time any request completes.</p>
+      } @else {
+        <p class="empty">No response has reached the subscriber yet.</p>
+      }
+    </div>
+  </div>
+
+  <div class="result-panel">
+    <h3>Subscriber log</h3>
+
+    @if (outputEvents.length === 0) {
+      <p class="empty">The log fills as each concurrent request completes.</p>
+    } @else {
+      <ul class="event-list compact">
+        @for (event of outputEvents; track event.requestId) {
+          <li>
+            <span class="time">t={{ event.atMs }}ms</span>
+            {{ event.message }}
+          </li>
+        }
+      </ul>
+    }
+  </div>
+</section>

--- a/src/app/demo-views/merge-map-demo-view/merge-map-demo-view.component.ts
+++ b/src/app/demo-views/merge-map-demo-view/merge-map-demo-view.component.ts
@@ -1,0 +1,21 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { OutputEvent, RequestRow, TypingEvent } from '../../demos/demo.models';
+
+@Component({
+  selector: 'app-merge-map-demo-view',
+  standalone: true,
+  templateUrl: './merge-map-demo-view.component.html'
+})
+export class MergeMapDemoViewComponent {
+  @Input() running = false;
+  @Input() typedTerm = '';
+  @Input() demoLetters: string[] = [];
+  @Input() typingEvents: TypingEvent[] = [];
+  @Input() requestRows: RequestRow[] = [];
+  @Input() outputEvents: OutputEvent[] = [];
+  @Input() latestResponse = '';
+
+  @Output() runDemo = new EventEmitter<void>();
+  @Output() resetDemo = new EventEmitter<void>();
+  @Output() backToMenu = new EventEmitter<void>();
+}

--- a/src/app/demo-views/switch-map-demo-view/switch-map-demo-view.component.html
+++ b/src/app/demo-views/switch-map-demo-view/switch-map-demo-view.component.html
@@ -1,0 +1,121 @@
+<section class="card controls">
+  <div>
+    <h2>Operator: switchMap</h2>
+    <p>Each new typed value starts a fresh inner request and cancels the previous one.</p>
+  </div>
+  <div class="actions">
+    <button type="button" (click)="runDemo.emit()" [disabled]="running">
+      {{ running ? 'Typing...' : 'Run demo' }}
+    </button>
+    <button type="button" (click)="resetDemo.emit()">Reset</button>
+    <button type="button" class="ghost" (click)="backToMenu.emit()">Back to menu</button>
+  </div>
+</section>
+
+<section class="card hero">
+  <div>
+    <p class="eyebrow">Typeahead simulation</p>
+    <h3>Search box: {{ typedTerm || '_' }}</h3>
+    <p class="caption">The outer stream emits C, CO, COM, COMP, and keeps going until COMPLETED.</p>
+  </div>
+
+  <div class="letter-strip" aria-label="Typing target word">
+    @for (letter of demoLetters; track $index) {
+      <span class="letter" [class.typed]="$index < typedTerm.length">
+        {{ letter }}
+      </span>
+    }
+  </div>
+</section>
+
+<section class="board">
+  <section class="card column">
+    <h3>Outer stream: typing</h3>
+    <p class="caption">Every key press emits the latest input value.</p>
+
+    @if (typingEvents.length === 0) {
+      <p class="empty">Run the demo to emit C, CO, COM, and the rest of the word.</p>
+    } @else {
+      <ul class="event-list">
+        @for (event of typingEvents; track event.id) {
+          <li>
+            <span class="time">t={{ event.atMs }}ms</span>
+            <code>{{ event.term }}</code>
+          </li>
+        }
+      </ul>
+    }
+  </section>
+
+  <section class="card column">
+    <h3>Inner stream: requests</h3>
+    <p class="caption">switchMap keeps only the latest request alive.</p>
+
+    @if (requestRows.length === 0) {
+      <p class="empty">No inner request has been created yet.</p>
+    } @else {
+      <div class="request-list">
+        @for (request of requestRows; track request.id) {
+          <article
+            class="request-card"
+            [class.canceled]="request.status === 'canceled'"
+            [class.completed]="request.status === 'completed'"
+          >
+            <div class="request-head">
+              <div>
+                <p class="request-label">Request {{ request.id }}</p>
+                <strong>{{ request.value }}</strong>
+              </div>
+              <span
+                class="status-chip"
+                [class.canceled]="request.status === 'canceled'"
+                [class.completed]="request.status === 'completed'"
+              >
+                {{ request.status }}
+              </span>
+            </div>
+
+            <div class="progress-track" aria-hidden="true">
+              <span class="progress-fill" [style.width.%]="request.progressPercent"></span>
+            </div>
+
+            <p class="request-note">{{ request.note }}</p>
+          </article>
+        }
+      </div>
+    }
+  </section>
+</section>
+
+<section class="card results">
+  <div class="result-panel">
+    <h3>After switchMap</h3>
+    <p class="caption">Canceled requests never reach the subscriber. Only the latest term survives.</p>
+
+    <div class="result-display">
+      @if (latestResponse.length > 0) {
+        <p class="result-message">{{ latestResponse }}</p>
+        <p class="result-note">Only "COMPLETED" makes it through after typing settles.</p>
+      } @else {
+        <p class="empty">No response has reached the subscriber yet.</p>
+      }
+    </div>
+  </div>
+
+  <div class="result-panel">
+    <h3>Subscriber log</h3>
+
+    @if (outputEvents.length === 0) {
+      <p class="empty">The log stays empty until the last request completes.</p>
+    } @else {
+      <ul class="event-list compact">
+        @for (event of outputEvents; track event.requestId) {
+          <li>
+            <span class="time">t={{ event.atMs }}ms</span>
+            {{ event.message }}
+          </li>
+        }
+      </ul>
+    }
+  </div>
+</section>

--- a/src/app/demo-views/switch-map-demo-view/switch-map-demo-view.component.ts
+++ b/src/app/demo-views/switch-map-demo-view/switch-map-demo-view.component.ts
@@ -1,0 +1,21 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { OutputEvent, RequestRow, TypingEvent } from '../../demos/demo.models';
+
+@Component({
+  selector: 'app-switch-map-demo-view',
+  standalone: true,
+  templateUrl: './switch-map-demo-view.component.html'
+})
+export class SwitchMapDemoViewComponent {
+  @Input() running = false;
+  @Input() typedTerm = '';
+  @Input() demoLetters: string[] = [];
+  @Input() typingEvents: TypingEvent[] = [];
+  @Input() requestRows: RequestRow[] = [];
+  @Input() outputEvents: OutputEvent[] = [];
+  @Input() latestResponse = '';
+
+  @Output() runDemo = new EventEmitter<void>();
+  @Output() resetDemo = new EventEmitter<void>();
+  @Output() backToMenu = new EventEmitter<void>();
+}

--- a/src/app/demos/demo.models.ts
+++ b/src/app/demos/demo.models.ts
@@ -1,4 +1,4 @@
-export type DemoOperator = 'switchMap' | 'exhaustMap';
+export type DemoOperator = 'switchMap' | 'mergeMap' | 'exhaustMap';
 export type RequestStatus = 'in-flight' | 'completed' | 'canceled';
 export type AttemptStatus = 'accepted' | 'ignored';
 

--- a/src/app/demos/merge-map-demo.ts
+++ b/src/app/demos/merge-map-demo.ts
@@ -1,0 +1,53 @@
+import { Observable, timer } from 'rxjs';
+import { last, map, mergeMap, take, tap } from 'rxjs';
+import { OutputEvent, SwitchMapDemoOptions } from './demo.models';
+
+export function createMergeMapDemo(
+  options: SwitchMapDemoOptions
+): Observable<void> {
+  const startedAt = Date.now();
+  const elapsedMs = () => Date.now() - startedAt;
+
+  return timer(0, options.typingDelayMs).pipe(
+    take(options.demoWord.length),
+    map((index) => options.demoWord.slice(0, index + 1)),
+    tap((term) => options.recordTypedTerm(term, elapsedMs())),
+    mergeMap((term) => createMergeMapRequestStream(term, options, elapsedMs))
+  );
+}
+
+function createMergeMapRequestStream(
+  term: string,
+  options: SwitchMapDemoOptions,
+  elapsedMs: () => number
+): Observable<void> {
+  const requestId = options.startRequest(
+    term,
+    'started immediately and will keep running beside newer requests'
+  );
+
+  return timer(options.requestStepDelayMs, options.requestStepDelayMs).pipe(
+    take(options.requestPhases.length),
+    tap((step) =>
+      options.advanceRequest(
+        requestId,
+        step + 1,
+        options.requestPhases[step] ?? 'processing request'
+      )
+    ),
+    last(),
+    map(() => {
+      const event: OutputEvent = {
+        requestId,
+        value: term,
+        message: 'Response delivered for "' + term + '"',
+        atMs: elapsedMs()
+      };
+
+      options.completeRequest(
+        event,
+        'response reached the subscriber without canceling other requests'
+      );
+    })
+  );
+}


### PR DESCRIPTION
### Motivation

- Add a `mergeMap` interactive visualization to demonstrate concurrent inner requests alongside the existing `switchMap` and `exhaustMap` demos.
- Split per-demo UI into standalone components to simplify `AppComponent` and separate rendering from demo logic.
- Improve README, menu layout, and styles to surface the new demo and make the feature grid configurable.

### Description

- Implemented a new demo pipeline in `src/app/demos/merge-map-demo.ts` exposing `createMergeMapDemo` that drives concurrent request streams via `mergeMap`.
- Componentized demo UIs by adding standalone view components and templates: `switch-map-demo-view`, `merge-map-demo-view`, and `exhaust-map-demo-view` under `src/app/demo-views/` and wired them into `AppComponent` imports.
- Updated `AppComponent` to use a `demoMenuItems` list, a single `openDemo` method, a `runMergeMapDemo` runner, and to render demo views with a template switch; added `ViewEncapsulation.None` and adjusted state handling accordingly.
- Expanded `demo.models.ts` to include `'mergeMap'`, added a tertiary `.feature-btn` style in `app.component.css`, and updated `README.md` with new demo descriptions, scripts, and repo layout.
- Updated unit tests in `src/app/app.component.spec.ts` to assert the menu includes `mergeMap` and that the `mergeMap` demo opens correctly.

### Testing

- Ran unit tests with `npm test` (Karma + Jasmine), which include the updated `AppComponent` specs, and they passed.
- Verified the landing screen test asserts presence of all feature buttons (including `mergeMap`) and the demo-opening tests for `mergeMap` and `exhaustMap` passed under the test runner.
- No automated lint or build failures were observed when running the test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30d2927c388324a24ca0a06e8fb363)