### PR TITLE
Add concatMap demo, view component, and model update

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,9 +4,9 @@ Purpose: make RxJS functions easy to understand by visualizing how values move t
 
 ## Demo Coverage Roadmap
 
-- [ ] Update `src/app/demos/demo.models.ts` to add the `concatMap` operator name.
-- [ ] Create `src/app/demos/concat-map-demo.ts` for the `concatMap` visualization scenario.
-- [ ] Create `src/app/demo-views/concat-map-demo-view/concat-map-demo-view.component.ts` for the `concatMap` view component.
+- [x] Update `src/app/demos/demo.models.ts` to add the `concatMap` operator name.
+- [x] Create `src/app/demos/concat-map-demo.ts` for the `concatMap` visualization scenario.
+- [x] Create `src/app/demo-views/concat-map-demo-view/concat-map-demo-view.component.ts` for the `concatMap` view component.
 - [ ] Create `src/app/demo-views/concat-map-demo-view/concat-map-demo-view.component.html` for the `concatMap` explanation and visualization layout.
 - [ ] Update `src/app/app.component.ts` to add `concatMap` to the demo menu.
 - [ ] Update `src/app/demos/demo.models.ts` to add the `map` operator name.

--- a/src/app/demo-views/concat-map-demo-view/concat-map-demo-view.component.ts
+++ b/src/app/demo-views/concat-map-demo-view/concat-map-demo-view.component.ts
@@ -1,0 +1,21 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { OutputEvent, RequestRow, TypingEvent } from '../../demos/demo.models';
+
+@Component({
+  selector: 'app-concat-map-demo-view',
+  standalone: true,
+  templateUrl: './concat-map-demo-view.component.html'
+})
+export class ConcatMapDemoViewComponent {
+  @Input() running = false;
+  @Input() typedTerm = '';
+  @Input() demoLetters: string[] = [];
+  @Input() typingEvents: TypingEvent[] = [];
+  @Input() requestRows: RequestRow[] = [];
+  @Input() outputEvents: OutputEvent[] = [];
+  @Input() latestResponse = '';
+
+  @Output() runDemo = new EventEmitter<void>();
+  @Output() resetDemo = new EventEmitter<void>();
+  @Output() backToMenu = new EventEmitter<void>();
+}

--- a/src/app/demos/concat-map-demo.ts
+++ b/src/app/demos/concat-map-demo.ts
@@ -1,0 +1,58 @@
+import { Observable, timer } from 'rxjs';
+import { concatMap, last, map, take, tap } from 'rxjs';
+import { OutputEvent, SwitchMapDemoOptions } from './demo.models';
+
+export function createConcatMapDemo(
+  options: SwitchMapDemoOptions
+): Observable<void> {
+  const startedAt = Date.now();
+  const elapsedMs = () => Date.now() - startedAt;
+
+  return timer(0, options.typingDelayMs).pipe(
+    take(options.demoWord.length),
+    map((index) => options.demoWord.slice(0, index + 1)),
+    tap((term) => options.recordTypedTerm(term, elapsedMs())),
+    concatMap((term, index) =>
+      createConcatMapRequestStream(term, index, options, elapsedMs)
+    )
+  );
+}
+
+function createConcatMapRequestStream(
+  term: string,
+  index: number,
+  options: SwitchMapDemoOptions,
+  elapsedMs: () => number
+): Observable<void> {
+  const requestId = options.startRequest(
+    term,
+    index === 0
+      ? 'started immediately as the first queued request'
+      : 'queued behind earlier requests and will run in order'
+  );
+
+  return timer(options.requestStepDelayMs, options.requestStepDelayMs).pipe(
+    take(options.requestPhases.length),
+    tap((step) =>
+      options.advanceRequest(
+        requestId,
+        step + 1,
+        options.requestPhases[step] ?? 'processing queued request'
+      )
+    ),
+    last(),
+    map(() => {
+      const event: OutputEvent = {
+        requestId,
+        value: term,
+        message: 'Queued response delivered for "' + term + '"',
+        atMs: elapsedMs()
+      };
+
+      options.completeRequest(
+        event,
+        'response reached the subscriber before the next queued request starts'
+      );
+    })
+  );
+}

--- a/src/app/demos/demo.models.ts
+++ b/src/app/demos/demo.models.ts
@@ -1,4 +1,4 @@
-export type DemoOperator = 'switchMap' | 'mergeMap' | 'exhaustMap';
+export type DemoOperator = 'switchMap' | 'mergeMap' | 'exhaustMap' | 'concatMap';
 export type RequestStatus = 'in-flight' | 'completed' | 'canceled';
 export type AttemptStatus = 'accepted' | 'ignored';
 


### PR DESCRIPTION
### Motivation

- Add a `concatMap` demonstration to the RxJS visualization product so the app can show how queued inner observables behave.

### Description

- Add a new standalone view component `src/app/demo-views/concat-map-demo-view/concat-map-demo-view.component.ts` with inputs for demo state and outputs for control events.
- Implement the concatMap demo driver in `src/app/demos/concat-map-demo.ts` that simulates typed terms, creates queued request streams using `concatMap`, and emits `OutputEvent` objects when requests complete.
- Update `src/app/demos/demo.models.ts` to include `concatMap` in the `DemoOperator` union type and leave related request/typing interfaces unchanged.
- Mark the corresponding tasks as completed in `TODO.md` for the `concatMap` items.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a365e310ea0832489a6340e8621e982)